### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe shell command constructed from library input

### DIFF
--- a/src/utils/themeLoader.ts
+++ b/src/utils/themeLoader.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -9,7 +9,7 @@ const require = createRequire(import.meta.url);
  */
 async function installTheme(packageName: string): Promise<void> {
   try {
-    execSync(`npm install ${packageName}`, {
+    execFileSync('npm', ['install', packageName], {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf8',
     });


### PR DESCRIPTION
Potential fix for [https://github.com/phoinixi/resuml/security/code-scanning/2](https://github.com/phoinixi/resuml/security/code-scanning/2)

To fix the issue, we should avoid dynamically constructing shell commands with untrusted input. Instead of using `execSync` with a string, we can use `execFileSync`, which accepts the command and its arguments as separate parameters. This approach avoids shell interpretation of the input, mitigating the risk of command injection.

Specifically:
1. Replace the `execSync` call in the `installTheme` function with `execFileSync`.
2. Pass the `npm` command and its arguments (`install` and the package name) as separate elements in an array.
3. Ensure that the `packageName` is passed as a single argument to `execFileSync`, preventing it from being interpreted as part of a larger shell command.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
