### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe shell command constructed from library input

### DIFF
--- a/src/utils/themeLoader.ts
+++ b/src/utils/themeLoader.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -9,7 +9,7 @@ const require = createRequire(import.meta.url);
  */
 async function installTheme(packageName: string): Promise<void> {
   try {
-    execSync(`npm install ${packageName}`, {
+    execFileSync('npm', ['install', packageName], {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf8',
     });


### PR DESCRIPTION
Potential fix for [https://github.com/phoinixi/resuml/security/code-scanning/1](https://github.com/phoinixi/resuml/security/code-scanning/1)

To fix the issue, we should avoid directly interpolating user-controlled input into a shell command. Instead, we can use the `execFileSync` function from the `child_process` module, which allows us to pass arguments as an array, thereby avoiding shell interpretation of the input. This approach ensures that the input is treated as a literal argument and not as part of the shell command.

Steps to implement the fix:
1. Replace the use of `execSync` with `execFileSync`.
2. Pass the `npm` command and its arguments (`install` and the package name) as separate elements in an array.
3. Ensure no other functionality is altered.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
