### PR TITLE
feat: add `resuml pdf` export command

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,14 @@
     "typescript": "^5.0.0",
     "vitest": "^3.2.2"
   },
+  "peerDependencies": {
+    "puppeteer": ">=20.0.0"
+  },
+  "peerDependenciesMeta": {
+    "puppeteer": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=20.0.0"
   },

--- a/src/commands/pdf.ts
+++ b/src/commands/pdf.ts
@@ -1,0 +1,120 @@
+import fs from 'fs';
+import path from 'node:path';
+import { processResumeData } from '../core';
+import { loadResumeFiles } from '../utils/loadResume';
+import { loadTheme } from '../utils/themeLoader';
+import { handleCommandError } from '../utils/errorHandler';
+import chalk from 'chalk';
+
+interface PdfCommandOptions {
+  resume?: string;
+  theme?: string;
+  output?: string;
+  language: string;
+  format: string;
+  margin?: string;
+  debug?: boolean;
+}
+
+interface PuppeteerBrowser {
+  newPage(): Promise<PuppeteerPage>;
+  close(): Promise<void>;
+}
+
+interface PuppeteerPage {
+  setContent(html: string, options?: { waitUntil?: string }): Promise<void>;
+  pdf(options?: Record<string, unknown>): Promise<Buffer>;
+}
+
+interface PuppeteerModule {
+  launch(options?: Record<string, unknown>): Promise<PuppeteerBrowser>;
+}
+
+async function loadPuppeteer(): Promise<PuppeteerModule> {
+  try {
+    const puppeteer = await import('puppeteer');
+    return puppeteer.default || puppeteer;
+  } catch {
+    throw new Error(
+      `Puppeteer is required for PDF export but is not installed.\n` +
+        `Install it with: ${chalk.cyan('npm install puppeteer')}\n` +
+        `Or for a smaller download: ${chalk.cyan('npm install puppeteer-core')}`
+    );
+  }
+}
+
+function parseMargin(margin?: string): Record<string, string> {
+  const defaultMargin = { top: '10mm', right: '10mm', bottom: '10mm', left: '10mm' };
+  if (!margin) return defaultMargin;
+
+  const parts = margin.split(',').map((s) => s.trim());
+  if (parts.length === 1) {
+    return { top: parts[0], right: parts[0], bottom: parts[0], left: parts[0] };
+  }
+  if (parts.length === 2) {
+    return { top: parts[0], right: parts[1], bottom: parts[0], left: parts[1] };
+  }
+  if (parts.length === 4) {
+    return { top: parts[0], right: parts[1], bottom: parts[2], left: parts[3] };
+  }
+  return defaultMargin;
+}
+
+export async function pdfAction(options: PdfCommandOptions): Promise<void> {
+  if (!options.theme) {
+    throw new Error(
+      '--theme option is required. Please specify a theme name (e.g., stackoverflow, react).'
+    );
+  }
+
+  console.log(chalk.blue('Starting resuml PDF export...'));
+
+  try {
+    // Load and process resume data
+    const inputPath = options.resume;
+    const { yamlContents } = await loadResumeFiles(inputPath);
+
+    console.log(chalk.blue('Processing and validating resume data...'));
+    const resumeData = await processResumeData(yamlContents);
+    console.log(chalk.green('Resume data processing and validation successful!'));
+
+    // Render HTML using theme
+    const theme = await loadTheme(options.theme);
+    const htmlOutput = await theme.render(resumeData, {
+      locale: options.language,
+    });
+
+    // Load puppeteer
+    console.log(chalk.blue('Loading Puppeteer...'));
+    const puppeteer = await loadPuppeteer();
+
+    // Convert HTML to PDF
+    const outputPath = options.output || 'resume.pdf';
+    const format = options.format === 'Letter' ? 'Letter' : 'A4';
+    const margin = parseMargin(options.margin);
+
+    console.log(chalk.blue(`Generating PDF (${format} format)...`));
+
+    const browser = await puppeteer.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(htmlOutput, { waitUntil: 'networkidle0' });
+
+      const pdfBuffer = await page.pdf({
+        format,
+        margin,
+        printBackground: true,
+        preferCSSPageSize: true,
+      });
+
+      fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+      fs.writeFileSync(outputPath, pdfBuffer);
+
+      console.log(chalk.green(`✅ Successfully generated ${outputPath}`));
+    } finally {
+      await browser.close();
+    }
+  } catch (error: unknown) {
+    handleCommandError(error, 'pdf', options.debug);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { toJsonAction } from './commands/tojson';
 import { renderAction } from './commands/render';
 import { devAction } from './commands/dev';
 import { initAction } from './commands/init';
+import { pdfAction } from './commands/pdf';
 
 // Get the directory name equivalent to __dirname in CommonJS
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
@@ -78,6 +79,19 @@ program
   .description('Scaffold a starter resume.yaml file with all sections.')
   .option('-o, --output <file>', 'Output YAML file path.', 'resume.yaml')
   .action(initAction);
+
+// PDF Command
+program
+  .command('pdf')
+  .description('Export resume as PDF using Puppeteer.')
+  .option('-r, --resume <path>', 'Input YAML file, directory, or glob pattern.')
+  .option('-t, --theme <name>', 'Theme name (e.g., stackoverflow, react).')
+  .option('-o, --output <file>', 'Output PDF file path.', 'resume.pdf')
+  .option('--language <code>', 'Language code for localization.', 'en')
+  .option('--format <size>', 'Page format: A4 or Letter.', 'A4')
+  .option('--margin <values>', 'Page margins (e.g., "10mm" or "10mm,15mm,10mm,15mm").')
+  .option('--debug', 'Show detailed validation and processing information.')
+  .action(pdfAction);
 
 // Parse Arguments - only execute when not in test environment
 if (process.env.NODE_ENV !== 'test') {


### PR DESCRIPTION
## Summary

Adds a `pdf` command that exports resumes as PDF files using Puppeteer.

## Features

- **Theme-based rendering**: Renders HTML using the specified theme, then converts to PDF
- **Optional dependency**: Puppeteer is an optional peer dependency — graceful error message if not installed
- **Page format**: Supports `--format A4` (default) and `--format Letter`
- **Custom margins**: Supports `--margin` with flexible syntax (single value, 2 values, or 4 values)
- **Full compatibility**: Supports all existing options (`--resume`, `--theme`, `--output`, `--language`, `--debug`)

## Usage

```bash
# Install puppeteer first
npm install puppeteer

# Basic usage
resuml pdf --resume resume.yaml --theme stackoverflow

# Full options
resuml pdf --resume resume.yaml --theme stackoverflow --output resume.pdf --format A4 --margin '10mm,15mm'
```

## Implementation

- Puppeteer is loaded dynamically at runtime with a clear error message if not available
- Uses `networkidle0` wait strategy to ensure all theme assets are loaded
- Prints with background colors enabled (`printBackground: true`)
- Respects CSS `@page` rules from themes (`preferCSSPageSize: true`)